### PR TITLE
Proper cache updating, handles events to keep cached guilds/channels fresh

### DIFF
--- a/Sources/DiscordKit/Gateway/DiscordGateway.swift
+++ b/Sources/DiscordKit/Gateway/DiscordGateway.swift
@@ -71,6 +71,7 @@ public class DiscordGateway: ObservableObject {
         }
         // Clear cache
         cache = CachedState()
+        objectWillChange.send()
         
         socket.close(code: .normalClosure)
         onAuthFailure.notify()
@@ -100,17 +101,21 @@ public class DiscordGateway: ObservableObject {
             self.cache.dms = d.private_channels
             self.cache.user = d.user
             self.cache.users = d.users
+            objectWillChange.send()
             
             log.info("Gateway ready")
         case .guildCreate:
             guard let d = data as? Guild else { return }
             self.cache.guilds?.insert(d, at: 0) // As per official Discord implementation
+            objectWillChange.send()
         case .guildDelete:
             guard let d = data as? GuildUnavailable else { return }
             self.cache.guilds?.removeAll { g in g.id == d.id }
+            objectWillChange.send()
         case .userUpdate:
             guard let updatedUser = data as? User else { return }
             self.cache.user = updatedUser
+            objectWillChange.send()
         case .presenceUpdate:
             break
             // guard let p = data as? PresenceUpdate else { return }

--- a/Sources/DiscordKit/Gateway/DiscordGateway.swift
+++ b/Sources/DiscordKit/Gateway/DiscordGateway.swift
@@ -38,7 +38,7 @@ public class DiscordGateway: ObservableObject {
     ///
     /// > In the future, presence updates and REST API requests will
     /// > also be stored and kept fresh in this cache.
-    @Published public var cache: CachedState = CachedState()
+    public var cache: CachedState = CachedState()
     
     private var evtListenerID: EventDispatch.HandlerIdentifier? = nil,
                 authFailureListenerID: EventDispatch.HandlerIdentifier? = nil,

--- a/Sources/DiscordKit/Gateway/DiscordGateway.swift
+++ b/Sources/DiscordKit/Gateway/DiscordGateway.swift
@@ -112,6 +112,25 @@ public class DiscordGateway: ObservableObject {
             guard let d = data as? GuildUnavailable else { return }
             self.cache.guilds?.removeAll { g in g.id == d.id }
             objectWillChange.send()
+        case .guildUpdate:
+            guard var d = data as? Guild else { return }
+            guard let idx = self.cache.guilds?.firstIndex(where: { g in g.id == d.id })
+            else { return }
+            
+            // Fuse the old guild with the updated guild
+            let oldGuild = self.cache.guilds![idx]
+            d.joined_at = oldGuild.joined_at
+            d.large = oldGuild.large
+            d.unavailable = oldGuild.unavailable
+            d.member_count = oldGuild.member_count
+            d.voice_states = oldGuild.voice_states
+            d.members = oldGuild.members
+            d.channels = oldGuild.channels
+            d.threads = oldGuild.threads
+            d.presences = oldGuild.presences
+            d.stage_instances = oldGuild.stage_instances
+            d.guild_scheduled_events = oldGuild.guild_scheduled_events
+            self.cache.guilds![idx] = d
         case .userUpdate:
             guard let updatedUser = data as? User else { return }
             self.cache.user = updatedUser

--- a/Sources/DiscordKit/Gateway/DiscordGateway.swift
+++ b/Sources/DiscordKit/Gateway/DiscordGateway.swift
@@ -131,6 +131,7 @@ public class DiscordGateway: ObservableObject {
             d.stage_instances = oldGuild.stage_instances
             d.guild_scheduled_events = oldGuild.guild_scheduled_events
             self.cache.guilds![idx] = d
+            objectWillChange.send()
         case .userUpdate:
             guard let updatedUser = data as? User else { return }
             self.cache.user = updatedUser

--- a/Sources/DiscordKit/Gateway/GatewayCachedState.swift
+++ b/Sources/DiscordKit/Gateway/GatewayCachedState.swift
@@ -9,10 +9,27 @@ import Foundation
 
 /// A struct for storing cached data from the Gateway
 ///
-/// See ``DiscordGateway/cache`` for more details.
+/// Used in ``DiscordGateway/cache``.
 public struct CachedState {
-	public var guilds: [Guild]?
-	public var dms: [Channel]?
+    /// Dictionary of guilds the user is in
+    ///
+    /// > The guild's ID is its key
+    public var guilds: [Snowflake: Guild] = [:]
+    
+    /// Sequence of guild IDs
+    ///
+    /// The IDs of ordered guilds are in this array. If the guild
+    /// is not ordered (i.e. never dragged from its initial position at
+    /// the top of the server list), its id will not be in this array.
+    public var guildSequence: [Snowflake] = []
+    
+    /// DM channels the user is in
+	public var dms: [Channel] = []
+    
+    /// Cached object of current user
 	public var user: User?
-	public var users: [User]? // Cached users, grows over time
+    
+    /// Cached users, initially populated from `READY` event and might
+    /// grow over time
+	public var users: [User] = []
 }

--- a/Sources/DiscordKit/Gateway/RobustWebSocket.swift
+++ b/Sources/DiscordKit/Gateway/RobustWebSocket.swift
@@ -39,7 +39,7 @@ public class RobustWebSocket: NSObject, ObservableObject {
     /// a (sessionOpen: Bool, reachable: Bool) tuple.
     public let onConnStateChange = EventDispatch<(Bool, Bool)>()
     
-    /// An `EventDispatch` that is notified when the session cannot be
+    /// An ``EventDispatch`` that is notified when the session cannot be
     /// resumed, most likely when the socket has been disconnected for too
     /// long and the session is invalidated. A fresh reconnection will
     /// be attempted if/when this happens.

--- a/Sources/DiscordKit/Objects/Gateway/ApplicationObj.swift
+++ b/Sources/DiscordKit/Objects/Gateway/ApplicationObj.swift
@@ -10,7 +10,9 @@
 
 import Foundation
 
-// Just to get things working, add full application later
+/// Partial application
+///
+/// Just to get things working, add full application later
 public struct PartialApplication: Codable, GatewayData {
 	public let id: Snowflake
 	public let flags: Int

--- a/Sources/DiscordKit/Objects/Gateway/Event/GatewayEvent.swift
+++ b/Sources/DiscordKit/Objects/Gateway/Event/GatewayEvent.swift
@@ -96,4 +96,6 @@ public enum GatewayEvent: String, Codable {
     
     // MARK: Human account-specific Events
     case channelUnreadUpdate = "CHANNEL_UNREAD_UPDATE"
+    case userSettingsUpdate = "USER_SETTINGS_UPDATE"
+    case userSettingsProtoUpdate = "USER_SETTINGS_PROTO_UPDATE"
 }

--- a/Sources/DiscordKit/Objects/Gateway/Gateway.swift
+++ b/Sources/DiscordKit/Objects/Gateway/Gateway.swift
@@ -117,6 +117,7 @@ public struct GatewayIncoming: Decodable {
                 
                 // User-specific events
             case .channelUnreadUpdate: d = try values.decode(ChannelUnreadUpdate.self, forKey: .d)
+            case .userSettingsUpdate: d = try values.decode(UserSettings.self, forKey: .d)
             default: d = nil
             }
         default:

--- a/Sources/DiscordKit/Objects/Guild.swift
+++ b/Sources/DiscordKit/Objects/Guild.swift
@@ -122,15 +122,15 @@ public struct Guild: GatewayData, Equatable, Identifiable {
     public let system_channel_id: Snowflake? // ID of channel for system-created messages
     public let system_channel_flags: Int
     public let rules_channel_id: Snowflake?
-    public let joined_at: ISOTimestamp?
-    public let large: Bool?
-    public let unavailable: Bool? // If guild is unavailable due to an outage
-    public let member_count: Int?
-    public let voice_states: [VoiceState]?
-    public let members: [Member]?
-    public let channels: [Channel]?
-    public let threads: [Channel]?
-    public let presences: [PresenceUpdate]?
+    public var joined_at: ISOTimestamp?
+    public var large: Bool?
+    public var unavailable: Bool? // If guild is unavailable due to an outage
+    public var member_count: Int?
+    public var voice_states: [VoiceState]?
+    public var members: [Member]?
+    public var channels: [Channel]?
+    public var threads: [Channel]?
+    public var presences: [PresenceUpdate]?
     public let max_presences: Int? // null is always returned, apart from the largest of guilds
     public let max_members: Int?
     public let vanity_url_code: String?
@@ -145,9 +145,9 @@ public struct Guild: GatewayData, Equatable, Identifiable {
     public let approximate_presence_count: Int? // Approximate number of non-offline members in this guild, returned from the GET /guilds/<id> endpoint when with_counts is true
     public let welcome_screen: GuildWelcomeScreen?
     public let nsfw_level: NSFWLevel
-    public let stage_instances: [StageInstance]?
+    public var stage_instances: [StageInstance]?
     public let stickers: [Sticker]?
-    public let guild_scheduled_events: [GuildScheduledEvent]?
+    public var guild_scheduled_events: [GuildScheduledEvent]?
     public let premium_progress_bar_enabled: Bool
 }
 

--- a/Sources/DiscordKit/Objects/Snowflake.swift
+++ b/Sources/DiscordKit/Objects/Snowflake.swift
@@ -7,48 +7,4 @@
 
 import Foundation
 
-public struct Snowflake: Identifiable, Codable, ExpressibleByStringLiteral, CustomStringConvertible, Equatable, Comparable, Hashable {
-	let rawValue: String
-
-	/// Identifiable
-
-	public var id: ObjectIdentifier {
-		ObjectIdentifier(rawValue as AnyObject)
-	}
-
-	/// Codable
-
-	public init(from decoder: Decoder) throws {
-		let container = try decoder.singleValueContainer()
-		if let str = try? container.decode(String.self) {
-			rawValue = str
-			return
-		}
-
-		let num = try container.decode(Double.self)
-		rawValue = String(num)
-	}
-
-	public func encode(to encoder: Encoder) throws {
-		var container = encoder.singleValueContainer()
-		try container.encode(rawValue)
-	}
-
-	/// ExpressibleByStringLiteral
-
-	public init(stringLiteral value: StringLiteralType) {
-		rawValue = value
-	}
-
-	/// CustomStringConvertible
-
-	public var description: String {
-		rawValue
-	}
-
-	/// Comparable
-
-	public static func < (lhs: Snowflake, rhs: Snowflake) -> Bool {
-		lhs.rawValue < rhs.rawValue
-	}
-}
+public typealias Snowflake = String


### PR DESCRIPTION
This PR handles channel and guild gateway events to keep cached data fresh. Please also view the [corresponding PR](https://github.com/SwiftcordApp/Swiftcord/pull/39) in Swiftcord for more info. This also ensures proper SwiftUI view rendering by calling `objectWillChange.send()` whenever the cache is modified. 

> Note: Breaking API changes were introduced, including changing the cached guilds from an array to a [guildID: guild] dictionary. They are relatively minor and should make it easier to use DiscordKit. Please look at Swiftcord for an implementation example.