### PR TITLE
Handle events related to DM support

### DIFF
--- a/Sources/DiscordKit/Gateway/DiscordGateway.swift
+++ b/Sources/DiscordKit/Gateway/DiscordGateway.swift
@@ -104,7 +104,7 @@ public class DiscordGateway: ObservableObject {
             + d.user_settings.guild_positions.compactMap({ id in d.guilds.first { g in g.id == id } })*/
             cache.dms = d.private_channels
             cache.user = d.user
-            cache.users = d.users
+            for user in d.users { cache.users.updateValue(user, forKey: user.id) }
             cache.guildSequence = d.user_settings.guild_positions
             
             log.info("Gateway ready")

--- a/Sources/DiscordKit/Gateway/DiscordGateway.swift
+++ b/Sources/DiscordKit/Gateway/DiscordGateway.swift
@@ -159,11 +159,20 @@ public class DiscordGateway: ObservableObject {
                 .firstIndex(where: { updatedCh.id == $0.id }) {
                 cache.guilds[updatedCh.guild_id!]?.channels?[chIdx] = updatedCh
             }
+        case .messageCreate:
+            guard let msg = data as? Message else { break }
+            if let guild = msg.guild_id,
+               let idx = cache.guilds[guild]?
+                .channels?
+                .firstIndex(where: { $0.id == msg.channel_id }) {
+                    cache.guilds[guild]?.channels?[idx].last_message_id = msg.id
+            } else if let idx = cache.dms.firstIndex(where: { $0.id == msg.channel_id }) {
+                cache.dms[idx].last_message_id = msg.id
+            }
         case .presenceUpdate:
-            break
-            // guard let p = data as? PresenceUpdate else { return }
-            //print("Presence update!")
-            //print(p)
+            guard let p = data as? PresenceUpdate else { return }
+            print("Presence update!")
+            print(p)
         default: break
         }
         objectWillChange.send()

--- a/Sources/DiscordKit/Gateway/GatewayCachedState.swift
+++ b/Sources/DiscordKit/Gateway/GatewayCachedState.swift
@@ -31,5 +31,5 @@ public struct CachedState {
     
     /// Cached users, initially populated from `READY` event and might
     /// grow over time
-	public var users: [User] = []
+    public var users: [Snowflake: User] = [:]
 }

--- a/Sources/DiscordKit/Objects/Channel.swift
+++ b/Sources/DiscordKit/Objects/Channel.swift
@@ -41,7 +41,7 @@ public struct Channel: Identifiable, Codable, GatewayData, Equatable {
     public let name: String?
     public let topic: String?
     public let nsfw: Bool?
-    public let last_message_id: Snowflake? // The id of the last message sent in this channel (may not point to an existing or valid message)
+    public var last_message_id: Snowflake? // The id of the last message sent in this channel (may not point to an existing or valid message)
     public let bitrate: Int?
     public let user_limit: Int?
     public let rate_limit_per_user: Int?

--- a/Sources/DiscordKit/Objects/Channel.swift
+++ b/Sources/DiscordKit/Objects/Channel.swift
@@ -46,6 +46,7 @@ public struct Channel: Identifiable, Codable, GatewayData, Equatable {
     public let user_limit: Int?
     public let rate_limit_per_user: Int?
     public let recipients: [User]?
+    public let recipient_ids: [Snowflake]?
     public let icon: String? // Icon hash of group DM
     public let owner_id: Snowflake?
     public let application_id: Snowflake?


### PR DESCRIPTION
[This is the corresponding PR in Swiftcord](https://github.com/SwiftcordApp/Swiftcord/pull/41)

Handles some events and updates cache with users sent in ready event. Allows proper first-class DM support in Swiftcord. 

What changed:
* `last_message_id` in channels are now updated (allows proper ordering of DMs)
* [Breaking] Cached users are now stored as a `[Snowflake: User]` dict instead of a `[User]` array