### PR TITLE
Handle and update more user settings

### DIFF
--- a/Sources/DiscordKit/Gateway/DiscordGateway.swift
+++ b/Sources/DiscordKit/Gateway/DiscordGateway.swift
@@ -141,7 +141,7 @@ public class DiscordGateway: ObservableObject {
             cache.user = updatedUser
         case .userSettingsUpdate:
             guard let newSettings = data as? UserSettings else { break }
-            cache.userSettings = newSettings
+            cache.userSettings = mergeUserSettings(cache.userSettings, new: newSettings)
         // Channel events
         case .channelCreate:
             guard let newCh = data as? Channel else { break }

--- a/Sources/DiscordKit/Gateway/RobustWebSocket.swift
+++ b/Sources/DiscordKit/Gateway/RobustWebSocket.swift
@@ -280,6 +280,8 @@ public class RobustWebSocket: NSObject, ObservableObject {
                 canResume = true
                 fallthrough
             case .resumed: sessionOpen = true
+            case .userSettingsUpdate:
+                print(message)
             default: break
             }
             onEvent.notify(event: (type, decoded.d))

--- a/Sources/DiscordKit/Gateway/RobustWebSocket.swift
+++ b/Sources/DiscordKit/Gateway/RobustWebSocket.swift
@@ -281,8 +281,6 @@ public class RobustWebSocket: NSObject, ObservableObject {
                 canResume = true
                 fallthrough
             case .resumed: sessionOpen = true
-            case .userSettingsUpdate:
-                print(message)
             default: break
             }
             onEvent.notify(event: (type, decoded.d))

--- a/Sources/DiscordKit/Gateway/RobustWebSocket.swift
+++ b/Sources/DiscordKit/Gateway/RobustWebSocket.swift
@@ -212,6 +212,7 @@ public class RobustWebSocket: NSObject, ObservableObject {
 			decoded = try JSONDecoder().decode(GatewayIncoming.self, from: message.data(using: .utf8) ?? Data())
 		} catch {
 			print(error)
+            print(message)
 			return
 		}
         

--- a/Sources/DiscordKit/Objects/Gateway/UserSettings.swift
+++ b/Sources/DiscordKit/Objects/Gateway/UserSettings.swift
@@ -12,35 +12,48 @@ public enum UITheme: String, Codable {
     case light = "light"
 }
 
+func mergeUserSettings(_ old: UserSettings?, new: UserSettings) -> UserSettings {
+    return UserSettings(
+        guild_positions: new.guild_positions ?? old?.guild_positions,
+        guild_folders: new.guild_folders ?? old?.guild_folders,
+        inline_attachment_media: new.inline_attachment_media ?? old?.inline_attachment_media,
+        locale: new.locale ?? old?.locale,
+        theme: new.theme ?? old?.theme,
+        timezone_offset: new.timezone_offset ?? old?.timezone_offset,
+        developer_mode: new.developer_mode ?? old?.developer_mode,
+        message_display_compact: new.message_display_compact ?? old?.message_display_compact
+    )
+}
+
 public struct UserSettings: Decodable, GatewayData {
     /// Sequence of guild IDs
     ///
     /// The IDs of ordered guilds are in this array. If the guild
     /// is not ordered (i.e. never dragged from its initial position at
     /// the top of the server list), its id will not be in this array.
-    public let guild_positions: [Snowflake]
+    public let guild_positions: [Snowflake]?
     
     /// Guild folders
-    public let guild_folders: [GuildFolder]
+    public let guild_folders: [GuildFolder]?
     
     /// If the new inline attachment upload experience is enabled
-    public let inline_attachment_media: Bool
+    public let inline_attachment_media: Bool?
     
     /// User interface locale
-    public let locale: Locale
+    public let locale: Locale?
     
     /// Client UI theme
     ///
     /// Although there's a sync with system setting in the official client,
     /// only light/dark themes are saved in the user settings. 
-    public let theme: UITheme
+    public let theme: UITheme?
     
     /// User timezone, in minutes
-    public let timezone_offset: Int
+    public let timezone_offset: Int?
     
     /// If developer mode is enabled (mainly enables copying of IDs)
-    public let developer_mode: Bool
+    public let developer_mode: Bool?
     
     /// If compact message view is enabled
-    public let message_display_compact: Bool
+    public let message_display_compact: Bool?
 }

--- a/Sources/DiscordKit/Objects/User.swift
+++ b/Sources/DiscordKit/Objects/User.swift
@@ -26,18 +26,49 @@ public enum UserFlags: Int, CaseIterable {
 
 public struct User: Codable, GatewayData {
     public let id: Snowflake
+    
+    /// Username of this user
     public let username: String
+    
+    /// Discriminator of this user
+    ///
+    /// A string in the format #0000
     public let discriminator: String
-    public let avatar: String? // User's avatar hash
+    
+    /// User's avatar hash
+    public let avatar: String?
+    
+    /// If this user is a bot
     public let bot: Bool?
+    
+    /// Bio of this user
     public let bio: String?
+    
+    /// If this user is a system user
     public let system: Bool?
-    public let mfa_enabled: Bool? // Whether the user has two factor enabled on their account
-    public let banner: String? // User's banner hash
+    
+    /// If the user has 2FA enabled on their account
+    public let mfa_enabled: Bool?
+    
+    /// Phone number associated with this account
+    ///
+    /// > Will only be present for the current user
+    public let phone: String?
+    
+    /// Email associated with this account
+    ///
+    /// > Will only be present for the current user
+    public let email: String?
+    
+    /// Banner image hash (nitro-only)
+    public let banner: String?
+    
+    /// Banner color
     public let accent_color: Int?
     public let locale: Locale?
+    
+    /// If the user's email is verified
     public let verified: Bool?
-    public let email: String?
     public let flags: Int?
     public let premium_type: Int?
     public let public_flags: Int?


### PR DESCRIPTION
Previously, only the guild ordering user setting was handled. This PR handles some other settings, and stores the whole user settings struct in the gateway cache. It also merges the updated user setting with the old struct when an update event is received since Discord only sends partial user settings in the update event.