### PR TITLE
Butter 🧈 

### DIFF
--- a/Sources/DiscordKit/Gateway/DiscordGateway.swift
+++ b/Sources/DiscordKit/Gateway/DiscordGateway.swift
@@ -177,7 +177,7 @@ public class DiscordGateway: ObservableObject {
             print(p)
         default: eventWasHandled = false
         }
-        if eventWasHandled { objectWillChange.send() }
+        if eventWasHandled { cache.objectWillChange.send() }
         onEvent.notify(event: (type, data))
         log.info("Dispatched event <\(type.rawValue, privacy: .public)>")
     }

--- a/Sources/DiscordKit/Gateway/DiscordGateway.swift
+++ b/Sources/DiscordKit/Gateway/DiscordGateway.swift
@@ -137,7 +137,7 @@ public class DiscordGateway: ObservableObject {
             cache.guilds[d.id] = d
         // User updates
         case .userUpdate:
-            guard let updatedUser = data as? User else { break }
+            guard let updatedUser = data as? CurrentUser else { break }
             cache.user = updatedUser
         case .userSettingsUpdate:
             guard let newSettings = data as? UserSettings else { break }

--- a/Sources/DiscordKit/Gateway/GatewayCachedState.swift
+++ b/Sources/DiscordKit/Gateway/GatewayCachedState.swift
@@ -10,7 +10,7 @@ import Foundation
 /// A struct for storing cached data from the Gateway
 ///
 /// Used in ``DiscordGateway/cache``.
-public struct CachedState {
+public class CachedState: ObservableObject {
     /// Dictionary of guilds the user is in
     ///
     /// > The guild's ID is its key

--- a/Sources/DiscordKit/Gateway/GatewayCachedState.swift
+++ b/Sources/DiscordKit/Gateway/GatewayCachedState.swift
@@ -20,7 +20,7 @@ public class CachedState: ObservableObject {
 	public var dms: [Channel] = []
     
     /// Cached object of current user
-	public var user: User?
+	public var user: CurrentUser?
     
     /// Cached users, initially populated from `READY` event and might
     /// grow over time

--- a/Sources/DiscordKit/Objects/Connection.swift
+++ b/Sources/DiscordKit/Objects/Connection.swift
@@ -23,8 +23,8 @@ public enum ConnectionType: String, Codable {
     case facebook = "facebook"
     case twitter = "twitter"
     case xbox = "xbox"
-    case battleNet = "battle.net" // Guess
-    // Cannot guess PlayStation Network
+    case battleNet = "battle.net"
+    case playstation = "playstation"
 }
 
 // Connections with external accounts (e.g. Reddit, YouTube, Steam etc.)

--- a/Sources/DiscordKit/Objects/Gateway/Event/ReadyEvt.swift
+++ b/Sources/DiscordKit/Objects/Gateway/Event/ReadyEvt.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct ReadyEvt: Decodable, GatewayData {
     public let v: Int
-    public let user: User
+    public let user: CurrentUser
     public let users: [User]
     public let guilds: [Guild]
     public let session_id: String

--- a/Sources/DiscordKit/Objects/Gateway/Gateway.swift
+++ b/Sources/DiscordKit/Objects/Gateway/Gateway.swift
@@ -112,7 +112,7 @@ public struct GatewayIncoming: Decodable {
             case .presenceUpdate: d = try values.decode(PresenceUpdate.self, forKey: .d)
                 // TODO: Add the remaining like 100 events
                 
-            case .userUpdate: d = try values.decode(User.self, forKey: .d)
+            case .userUpdate: d = try values.decode(CurrentUser.self, forKey: .d)
             case .typingStart: d = try values.decode(TypingStart.self, forKey: .d)
                 
                 // User-specific events

--- a/Sources/DiscordKit/Objects/User.swift
+++ b/Sources/DiscordKit/Objects/User.swift
@@ -125,7 +125,7 @@ public extension User {
     }
 }
 public extension CurrentUser {
-    var flagsArr: [UserFlags]? {
+    var flagsArr: [UserFlags] {
         flags.decodeFlags(flags: UserFlags.staff)
     }
 }

--- a/Sources/DiscordKit/Objects/User.swift
+++ b/Sources/DiscordKit/Objects/User.swift
@@ -24,7 +24,11 @@ public enum UserFlags: Int, CaseIterable {
     case botHTTPInteractions = 19
 }
 
-public struct User: Codable, GatewayData {
+public struct User: Codable, GatewayData, Equatable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id
+    }
+    
     public let id: Snowflake
     
     /// Username of this user

--- a/Sources/DiscordKit/Objects/User.swift
+++ b/Sources/DiscordKit/Objects/User.swift
@@ -124,3 +124,8 @@ public extension User {
 		flags?.decodeFlags(flags: UserFlags.staff)
     }
 }
+public extension CurrentUser {
+    var flagsArr: [UserFlags]? {
+        flags.decodeFlags(flags: UserFlags.staff)
+    }
+}

--- a/Sources/DiscordKit/Objects/User.swift
+++ b/Sources/DiscordKit/Objects/User.swift
@@ -87,8 +87,8 @@ public struct CurrentUser: Codable, GatewayData {
     /// A string in the format #0000
     public let discriminator: String
     
-    public let public_flags: Int
-    public let purchased_flags: Int
+    public let public_flags: Int?
+    public let purchased_flags: Int?
     
     public let premium: Bool
     public let nsfw_allowed: Bool

--- a/Sources/DiscordKit/Objects/User.swift
+++ b/Sources/DiscordKit/Objects/User.swift
@@ -50,16 +50,6 @@ public struct User: Codable, GatewayData {
     /// If the user has 2FA enabled on their account
     public let mfa_enabled: Bool?
     
-    /// Phone number associated with this account
-    ///
-    /// > Will only be present for the current user
-    public let phone: String?
-    
-    /// Email associated with this account
-    ///
-    /// > Will only be present for the current user
-    public let email: String?
-    
     /// Banner image hash (nitro-only)
     public let banner: String?
     
@@ -72,6 +62,51 @@ public struct User: Codable, GatewayData {
     public let flags: Int?
     public let premium_type: Int?
     public let public_flags: Int?
+}
+
+public struct CurrentUser: Codable, GatewayData {
+    /// Phone number associated with this account
+    ///
+    /// > Will only be present for the current user, and is nil
+    /// > if the user did not add a number to the account
+    public let phone: String?
+    
+    /// Email associated with this account
+    ///
+    /// > Will only be present for the current user
+    public let email: String
+    
+    /// ID of the current user
+    public let id: Snowflake
+    
+    /// Username of this user
+    public let username: String
+    
+    /// Discriminator of this user
+    ///
+    /// A string in the format #0000
+    public let discriminator: String
+    
+    public let public_flags: Int
+    public let purchased_flags: Int
+    
+    public let premium: Bool
+    public let nsfw_allowed: Bool
+    public let mobile: Bool
+    public let desktop: Bool
+    public let mfa_enabled: Bool
+    public let flags: Int
+    
+    public let bio: String?
+    
+    /// Banner color
+    public let accent_color: Int?
+    
+    /// Banner image hash (nitro-only)
+    public let banner: String?
+    
+    /// User's avatar hash
+    public let avatar: String?
 }
 
 // User profile endpoint is undocumented

--- a/Sources/DiscordKit/Objects/User.swift
+++ b/Sources/DiscordKit/Objects/User.swift
@@ -25,6 +25,25 @@ public enum UserFlags: Int, CaseIterable {
 }
 
 public struct User: Codable, GatewayData, Equatable {
+    // To work around the default access level
+    public init(id: Snowflake, username: String, discriminator: String, avatar: String?, bot: Bool?, bio: String?, system: Bool?, mfa_enabled: Bool?, banner: String?, accent_color: Int?, locale: Locale?, verified: Bool?, flags: Int?, premium_type: Int?, public_flags: Int?) {
+        self.id = id
+        self.username = username
+        self.discriminator = discriminator
+        self.avatar = avatar
+        self.bot = bot
+        self.bio = bio
+        self.system = system
+        self.mfa_enabled = mfa_enabled
+        self.banner = banner
+        self.accent_color = accent_color
+        self.locale = locale
+        self.verified = verified
+        self.flags = flags
+        self.premium_type = premium_type
+        self.public_flags = public_flags
+    }
+    
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.id == rhs.id
     }
@@ -115,6 +134,15 @@ public struct CurrentUser: Codable, GatewayData {
 
 // User profile endpoint is undocumented
 public struct UserProfile: Codable, GatewayData {
+    public init(connected_accounts: [Connection], guild_member: Member?, premium_guild_since: ISOTimestamp?, premium_since: ISOTimestamp?, mutual_guilds: [MutualGuild]?, user: User) {
+        self.connected_accounts = connected_accounts
+        self.guild_member = guild_member
+        self.premium_guild_since = premium_guild_since
+        self.premium_since = premium_since
+        self.mutual_guilds = mutual_guilds
+        self.user = user
+    }
+    
     public let connected_accounts: [Connection]
     public let guild_member: Member?
     public let premium_guild_since: ISOTimestamp?


### PR DESCRIPTION
Performance improvements. Corresponding PR for butter branch in Swiftcord.

Optimisations are not as major as those in Swiftcord, and changes were more to support those made in Swiftcord.

Breaking change: user in gateway cache is now a `CurrentUser` struct.,