### PR TITLE
Active Developer Badge Support

### DIFF
--- a/Sources/DiscordKitCommon/Objects/User+Flags.swift
+++ b/Sources/DiscordKitCommon/Objects/User+Flags.swift
@@ -47,6 +47,8 @@ public extension User {
 
         /// Discord Certified Moderator
         public static let certifiedModerator = Flags(rawValue: 1 << 18)
+        
+        public static let activeDeveloper = Flags(rawValue: 1 << 22)
 
         /// Bot uses only [HTTP interactions](https://discord.com/developers/docs/interactions/receiving-and-responding#receiving-an-interaction) and is shown in the online member list
         public static let botHTTPInteractions = Flags(rawValue: 1 << 19)
@@ -65,7 +67,8 @@ public extension User {
             .verifiedBot,
             .verifiedDeveloper,
             .certifiedModerator,
-            .botHTTPInteractions
+            .botHTTPInteractions,
+            .activeDeveloper
         ]
 
         // MARK: Hashable

--- a/Sources/DiscordKitCore/DiscordKitCore.swift
+++ b/Sources/DiscordKitCore/DiscordKitCore.swift
@@ -8,7 +8,7 @@
 import Foundation
 import os
 
-public class DiscordREST: ObservableObject {
+public class DiscordREST {
     static let subsystem = "com.cryptoalgo.discordapi"
 
     static let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? DiscordREST.subsystem, category: "DiscordREST")

--- a/Sources/DiscordKitCore/DiscordKitCore.swift
+++ b/Sources/DiscordKitCore/DiscordKitCore.swift
@@ -8,7 +8,7 @@
 import Foundation
 import os
 
-public class DiscordREST {
+public class DiscordREST: ObservableObject {
     static let subsystem = "com.cryptoalgo.discordapi"
 
     static let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? DiscordREST.subsystem, category: "DiscordREST")


### PR DESCRIPTION
This adds support for the active developer badge on the backend.

The [Update DiscordKitCore.swift](https://github.com/SwiftcordApp/DiscordKit/commit/dcd55bb32bca5fec6f2504d91b529ed3e57450ee) commit was needed for compilation on my end (with the frontend), you may not need it