### PR TITLE
Sticker Packs

### DIFF
--- a/Sources/DiscordKitCore/Objects/Data/Sticker.swift
+++ b/Sources/DiscordKitCore/Objects/Data/Sticker.swift
@@ -39,3 +39,13 @@ public struct StickerItem: Codable, Identifiable {
     public let name: String
     public let format_type: StickerFormat
 }
+
+public struct StickerPack: Codable, GatewayData {
+    public let id: Snowflake
+    public let stickers: [StickerItem]
+    public let name: String
+    public let sku_id: Snowflake
+    public let cover_sticker_id: Snowflake?
+    public let description: String
+    public let banner_asset_id: HashedAsset?
+}

--- a/Sources/DiscordKitCore/REST/APISticker.swift
+++ b/Sources/DiscordKitCore/REST/APISticker.swift
@@ -2,6 +2,10 @@
 
 import Foundation
 
+private struct StickerPacks: Codable, GatewayData {
+    public let sticker_packs: [StickerPack]
+}
+
 public extension DiscordREST {
     /// Get Sticker
     ///
@@ -16,10 +20,11 @@ public extension DiscordREST {
     /// List Nitro Sticker Packs
     ///
     /// > GET: `/sticker-packs`
-    func listNitroStickerPacks<T: Decodable>() async throws -> T {
-        return try await getReq(
+    func listNitroStickerPacks() async throws -> [StickerPack] {
+        let stickerPacks: StickerPacks = try await getReq(
             path: "sticker-packs"
         )
+        return stickerPacks.sticker_packs
     }
     /// List Guild Stickers
     ///

--- a/Sources/DiscordKitCore/Utils/HashedAsset.swift
+++ b/Sources/DiscordKitCore/Utils/HashedAsset.swift
@@ -83,6 +83,21 @@ public extension HashedAsset {
         return HashedAsset.joinPaths(with: format, "icons", guildID, self)
             .setSize(size: size)
     }
+    
+    /// Returns the icon URL of a sticker pack banner
+    ///
+    /// > This resource will not be animated.
+    ///
+    /// - Parameters:
+    ///  - format: Format of banner (PNG, JPEG, WebP)
+    ///  - size: Size of asset, a power of 2 from 16 to 4096
+    func stickerPackBannerURL(
+        with format: AssetFormat = .png,
+        size: Int? = nil
+    ) -> URL {
+        return HashedAsset.joinPaths(with: format, "app-assets", "710982414301790216", "store", self)
+            .setSize(size: size)
+    }
 }
 
 public extension HashedAsset {


### PR DESCRIPTION
Added support for Sticker Pack stuff.

- Added a `StickerPack` codable that holds information about a sticker pack.
- Changed `listNitroStickerPacks` to always return `[StickerPack]`. I couldn't figure out how to make it work with generic types - if you'd rather we keep the generic-type functionality and know how to implement this, let me know
- Added `stickerPackBannerURL` to `HashedAsset`

Using `listNitroStickerPacks` looks like this:
```swift
guard let stickerPacks: [StickerPack] = try? await restAPI.listNitroStickerPacks() else {return nil}
```

Using `stickerPackBannerURL` looks like this:
```swift
pack.banner_asset_id?.stickerPackBannerURL(with: .webp, size: 1024)
```