### PR TITLE
[DRAFT] feat(interaction): added user & channel options to command options

### DIFF
--- a/Sources/DiscordKitBot/ApplicationCommand/CommandData.swift
+++ b/Sources/DiscordKitBot/ApplicationCommand/CommandData.swift
@@ -87,6 +87,21 @@ public extension CommandData {
     typealias OptionData = Interaction.Data.AppCommandData.OptionData
 }
 
+public extension CommandData {
+    func subGroup(name: String) -> CommandData? {
+        guard let option = optionValues[name], option.type == .subCommandGroup else { return nil }
+        guard let options = option.options else { return nil }
+        guard let rest = self.rest else { return nil }
+        return CommandData(
+            optionValues: options,
+            rest: rest,
+            applicationID: self.applicationID,
+            interactionID: self.interactionID,
+            token: self.token
+        )
+    }
+}
+
 // MARK: - Callback APIs
 public extension CommandData {
     /// Wrapper function to send an interaction response with the current interaction's ID and token

--- a/Sources/DiscordKitBot/ApplicationCommand/CommandData.swift
+++ b/Sources/DiscordKitBot/ApplicationCommand/CommandData.swift
@@ -12,14 +12,21 @@ import DiscordKitCore
 public class CommandData {
     internal init(
         optionValues: [OptionData],
-        rest: DiscordREST, applicationID: String, interactionID: Snowflake, token: String
+        rest: DiscordREST,
+        applicationID: String,
+        guildID: Snowflake?,
+        interactionID: Snowflake,
+        token: String,
+        resolved: ResolvedData?
     ) {
         self.rest = rest
         self.token = token
+        self.guildID = guildID
         self.interactionID = interactionID
         self.applicationID = applicationID
 
         self.optionValues = Self.unwrapOptionDatas(optionValues)
+        self.resolved = resolved
     }
 
     /// A private reference to the active rest handler for handling actions
@@ -40,8 +47,13 @@ public class CommandData {
     // MARK: Parameters for executing callbacks
     /// The token to use when carrying out actions with this interaction
     let token: String
+
+    public let guildID: Snowflake?
+
     /// The ID of this interaction
     public let interactionID: Snowflake
+
+    public let resolved: ResolvedData?
 
     fileprivate static func unwrapOptionDatas(_ options: [OptionData]) -> [String: OptionData] {
         var optValues: [String: OptionData] = [:]
@@ -85,6 +97,7 @@ public extension CommandData {
 
     /// The wrapped value of an option
     typealias OptionData = Interaction.Data.AppCommandData.OptionData
+    typealias ResolvedData = Interaction.Data.AppCommandData.ResolvedData
 }
 
 public extension CommandData {
@@ -96,8 +109,10 @@ public extension CommandData {
             optionValues: options,
             rest: rest,
             applicationID: self.applicationID,
+            guildID: self.guildID,
             interactionID: self.interactionID,
-            token: self.token
+            token: self.token,
+            resolved: self.resolved
         )
     }
 }

--- a/Sources/DiscordKitBot/ApplicationCommand/Option/ChannelOption.swift
+++ b/Sources/DiscordKitBot/ApplicationCommand/Option/ChannelOption.swift
@@ -1,0 +1,30 @@
+//
+//  ChannelOption.swift
+//
+//
+//  Created by Elizabeth on 02/10/2025.
+//
+
+import Foundation
+import DiscordKitCore
+
+/// An option for an application command that accepts a server channel
+public struct ChannelOption: CommandOption {
+    public init(_ name: String, description: String, `required`: Bool? = nil, channel_types: [ChannelType]? = nil) {
+        type = .channel
+
+        self.required = `required`
+        self.name = name
+        self.description = description
+        self.channel_types = channel_types
+    }
+
+    public var type: CommandOptionType
+
+    public var required: Bool?
+
+    public let name: String
+    public let description: String
+
+    public let channel_types: [ChannelType]?
+}

--- a/Sources/DiscordKitBot/ApplicationCommand/Option/SubCommandGroup.swift
+++ b/Sources/DiscordKitBot/ApplicationCommand/Option/SubCommandGroup.swift
@@ -1,0 +1,69 @@
+//
+//  SubCommandGroup.swift
+//
+//
+//  Created by Elizabeth on 11/02/2025.
+//
+
+import DiscordKitCore
+import Foundation
+
+public struct SubCommandGroup: CommandOption {
+    /// Create a sub-command, optionally with an array of options
+    public init(_ name: String, description: String, options: [SubCommand]? = nil) {
+        type = .subCommandGroup
+
+        self.name = name
+        self.description = description
+        self.options = options
+    }
+
+    /// Create a sub-command with options built by an ``OptionBuilder``
+    public init(
+        _ name: String, description: String, @SubCommandOptionBuilder options: () -> [SubCommand]
+    ) {
+        self.init(name, description: description, options: options())
+    }
+
+    public let type: CommandOptionType
+
+    public let name: String
+
+    public let description: String
+
+    public var required: Bool?
+
+    /// If this command is a subcommand or subcommand group type, these nested options will be its parameters
+    public let options: [SubCommand]?
+
+    enum CodingKeys: CodingKey {
+        case type
+        case name
+        case description
+        case required
+        case options
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container: KeyedEncodingContainer<SubCommand.CodingKeys> = encoder.container(
+            keyedBy: SubCommand.CodingKeys.self)
+
+        try container.encode(self.type, forKey: SubCommand.CodingKeys.type)
+        try container.encode(self.name, forKey: SubCommand.CodingKeys.name)
+        try container.encode(self.description, forKey: SubCommand.CodingKeys.description)
+        try container.encodeIfPresent(self.required, forKey: SubCommand.CodingKeys.required)
+        if let options = options {
+            var optContainer = container.nestedUnkeyedContainer(forKey: .options)
+            for option in options {
+                try optContainer.encode(option)
+            }
+        }
+    }
+}
+
+@resultBuilder
+public struct SubCommandOptionBuilder {
+    public static func buildBlock(_ components: SubCommand...) -> [SubCommand] {
+        components
+    }
+}

--- a/Sources/DiscordKitBot/ApplicationCommand/Option/UserOption.swift
+++ b/Sources/DiscordKitBot/ApplicationCommand/Option/UserOption.swift
@@ -1,0 +1,36 @@
+//
+//  File.swift
+//  
+//
+//  Created by Elizabeth (lizclipse) on 09/08/2023.
+//
+
+import Foundation
+import DiscordKitCore
+
+public struct UserOption: CommandOption {
+    public init(_ name: String, description: String, `required`: Bool? = nil, choices: [AppCommandOptionChoice]? = nil, minLength: Int? = nil, maxLength: Int? = nil, autocomplete: Bool? = nil) {
+        type = .user
+
+        self.required = `required`
+        self.choices = choices
+        self.name = name
+        self.description = description
+        self.autocomplete = autocomplete
+    }
+
+    public var type: CommandOptionType
+
+    public var required: Bool?
+
+    /// Choices for the user to pick from
+    ///
+    /// > Important: There can be a max of 25 choices.
+    public let choices: [AppCommandOptionChoice]?
+
+    public let name: String
+    public let description: String
+
+    /// If autocomplete interactions are enabled for this option
+    public let autocomplete: Bool?
+}

--- a/Sources/DiscordKitBot/ApplicationCommand/Option/UserOption.swift
+++ b/Sources/DiscordKitBot/ApplicationCommand/Option/UserOption.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  UserOption.swift
 //  
 //
 //  Created by Elizabeth (lizclipse) on 09/08/2023.

--- a/Sources/DiscordKitBot/BotMessage.swift
+++ b/Sources/DiscordKitBot/BotMessage.swift
@@ -14,17 +14,26 @@ import DiscordKitCore
 /// > Internally, `Message`s are converted to and from this type
 /// > for easier use
 public struct BotMessage {
-    public let content: String
-    public let channelID: Snowflake // This will be changed very soon
-    public let id: Snowflake // This too
+//    public let content: String
+//    public let channelID: Snowflake // This will be changed very soon
+//    public let id: Snowflake // This too
+//    public let author: User
+    
+    public var content: String { get { return inner.content } }
+    public var channelID: Snowflake { get { return inner.channel_id } }
+    public var id: Snowflake { get { return inner.id } }
+    
+    public let inner: Message
 
     // The REST handler associated with this message, used for message actions
     fileprivate weak var rest: DiscordREST?
 
     internal init(from message: Message, rest: DiscordREST) {
-        content = message.content
-        channelID = message.channel_id
-        id = message.id
+        self.inner = message
+//        content = message.content
+//        channelID = message.channel_id
+//        id = message.id
+//        author = message.author
 
         self.rest = rest
     }

--- a/Sources/DiscordKitBot/BotMessage.swift
+++ b/Sources/DiscordKitBot/BotMessage.swift
@@ -1,12 +1,12 @@
 //
 //  BotMessage.swift
-//  
+//
 //
 //  Created by Vincent Kwok on 22/11/22.
 //
 
-import Foundation
 import DiscordKitCore
+import Foundation
 
 /// A Discord message, with convenience methods
 ///
@@ -14,15 +14,41 @@ import DiscordKitCore
 /// > Internally, `Message`s are converted to and from this type
 /// > for easier use
 public struct BotMessage {
-//    public let content: String
-//    public let channelID: Snowflake // This will be changed very soon
-//    public let id: Snowflake // This too
-//    public let author: User
-    
-    public var content: String { get { return inner.content } }
-    public var channelID: Snowflake { get { return inner.channel_id } }
-    public var id: Snowflake { get { return inner.id } }
-    
+    public var id: Snowflake { return inner.id }
+    public var channelID: Snowflake { return inner.channel_id }
+    public var guildID: Snowflake? { return inner.guild_id }
+    public var author: User { return inner.author }
+    public var member: Member? { return inner.member }
+    public var timestamp: Date { return inner.timestamp }
+    public var editedTimestamp: Date? { return inner.edited_timestamp }
+    public var tts: Bool { return inner.tts }
+    public var mentionEveryone: Bool { return inner.mention_everyone }
+    public var mentions: [User] { return inner.mentions }
+    public var mentionRoles: [Snowflake] { return inner.mention_roles }
+    public var mentionChannels: [ChannelMention]? { return inner.mention_channels }
+    public var attachments: [Attachment] { return inner.attachments }
+    public var embeds: [Embed] { return inner.embeds }
+    public var reactions: [Reaction]? { return inner.reactions }
+    public var nonce: Nonce? { return inner.nonce }
+    public var pinned: Bool { return inner.pinned }
+    public var webhookId: Snowflake? { return inner.webhook_id }
+    public var type: MessageType { return inner.type }
+    public var activity: MessageActivity? { return inner.activity }
+    public var application: Application? { return inner.application }
+    public var applicationId: Snowflake? { return inner.application_id }
+    public var messageReference: MessageReference? { return inner.message_reference }
+    public var flags: Int? { return inner.flags }
+    public var referencedMessage: BotMessage? {
+        guard let ref = inner.referenced_message else { return nil }
+        return Self(from: ref, rest: self.rest!)
+    }
+    public var interaction: MessageInteraction? { return inner.interaction }
+    public var thread: Channel? { return inner.thread }
+    public var components: [MessageComponent]? { return inner.components }
+    public var stickerItems: [StickerItem]? { return inner.sticker_items }
+    public var call: CallMessageComponent? { return inner.call }
+    public var content: String { return inner.content }
+
     public let inner: Message
 
     // The REST handler associated with this message, used for message actions
@@ -30,20 +56,20 @@ public struct BotMessage {
 
     internal init(from message: Message, rest: DiscordREST) {
         self.inner = message
-//        content = message.content
-//        channelID = message.channel_id
-//        id = message.id
-//        author = message.author
-
         self.rest = rest
     }
 }
 
-public extension BotMessage {
-    func reply(_ content: String) async throws -> Message {
+extension BotMessage {
+    public func reply(_ content: String) async throws -> Message {
         return try await rest!.createChannelMsg(
-            message: .init(content: content, message_reference: .init(message_id: id), components: []),
+            message: .init(
+                content: content, message_reference: .init(message_id: id), components: []),
             id: channelID
         )
+    }
+
+    public func mentions(_ userID: Snowflake) -> Bool {
+        return mentions.first(identifiedBy: userID) != nil
     }
 }

--- a/Sources/DiscordKitBot/Client.swift
+++ b/Sources/DiscordKitBot/Client.swift
@@ -108,13 +108,18 @@ extension Client {
     public var isReady: Bool { gateway?.sessionOpen == true }
 
     /// Invoke the handler associated with the respective commands
-    private func invokeCommandHandler(_ commandData: Interaction.Data.AppCommandData, id: Snowflake, token: String) {
+    private func invokeCommandHandler(_ commandData: Interaction.Data.AppCommandData, id: Snowflake, token: String, guildID: Snowflake?) {
         if let handler = appCommandHandlers[commandData.id] {
             Self.logger.trace("Invoking application handler", metadata: ["command.name": "\(commandData.name)"])
             Task {
                 await handler(.init(
                     optionValues: commandData.options ?? [],
-                    rest: rest, applicationID: applicationID!, interactionID: id, token: token
+                    rest: rest,
+                    applicationID: applicationID!,
+                    guildID: guildID,
+                    interactionID: id,
+                    token: token,
+                    resolved: commandData.resolved
                 ))
             }
         }
@@ -143,7 +148,7 @@ extension Client {
             // Handle interactions based on type
             switch interaction.data {
             case .applicationCommand(let commandData):
-                invokeCommandHandler(commandData, id: interaction.id, token: interaction.token)
+                invokeCommandHandler(commandData, id: interaction.id, token: interaction.token, guildID: interaction.guildID)
             case .messageComponent(let componentData):
                 print("Component interaction: \(componentData.custom_id)")
             default: break

--- a/Sources/DiscordKitCore/Objects/Data/Interaction.swift
+++ b/Sources/DiscordKitCore/Objects/Data/Interaction.swift
@@ -72,6 +72,7 @@ public struct Interaction: Decodable {
                     case integer(Int)
                     case double(Double)
                     case boolean(Bool) // Discord docs are disappointing
+                    case user(Snowflake)
 
                     public func encode(to encoder: Encoder) throws {
                         var container = encoder.singleValueContainer()
@@ -80,6 +81,7 @@ public struct Interaction: Decodable {
                         case .integer(let val): try container.encode(val)
                         case .double(let val): try container.encode(val)
                         case .boolean(let val): try container.encode(val)
+                        case .user(let val): try container.encode(val)
                         }
                     }
 
@@ -87,7 +89,10 @@ public struct Interaction: Decodable {
                     ///
                     /// - Returns: The string value of a certain option if it is present and is of type `String`, otherwise `nil`
                     public func value() -> String? {
-                        guard case let .string(val) = self else { return nil }
+                        guard case let .string(val) = self else {
+                            guard case let .user(val) = self else { return nil }
+                            return val
+                        }
                         return val
                     }
                     /// Get the wrapped `Int` value
@@ -145,6 +150,7 @@ public struct Interaction: Decodable {
                     case .number: value = .double(try container.decode(Double.self, forKey: .value))
                     case .boolean: value = .boolean(try container.decode(Bool.self, forKey: .value))
                     case .string: value = .string(try container.decode(String.self, forKey: .value))
+                    case .user: value = .user(try container.decode(Snowflake.self, forKey: .value))
                     default: value = nil
                     }
                 }

--- a/Sources/DiscordKitCore/Objects/Data/Interaction.swift
+++ b/Sources/DiscordKitCore/Objects/Data/Interaction.swift
@@ -61,6 +61,8 @@ public struct Interaction: Decodable {
             public let name: String
             /// Type of command
             public let type: Int
+            /// Resolved references for things like user and channels
+            public let resolved: ResolvedData?
             /// Options of command (present if the command has options)
             public let options: [OptionData]?
 
@@ -157,6 +159,10 @@ public struct Interaction: Decodable {
                     default: value = nil
                     }
                 }
+            }
+
+            public struct ResolvedData: Codable {
+                public let channels: [Snowflake: Channel]?
             }
         }
 

--- a/Sources/DiscordKitCore/Objects/Data/Interaction.swift
+++ b/Sources/DiscordKitCore/Objects/Data/Interaction.swift
@@ -73,6 +73,7 @@ public struct Interaction: Decodable {
                     case double(Double)
                     case boolean(Bool) // Discord docs are disappointing
                     case user(Snowflake)
+                    case channel(String)
 
                     public func encode(to encoder: Encoder) throws {
                         var container = encoder.singleValueContainer()
@@ -82,6 +83,7 @@ public struct Interaction: Decodable {
                         case .double(let val): try container.encode(val)
                         case .boolean(let val): try container.encode(val)
                         case .user(let val): try container.encode(val)
+                        case .channel(let val): try container.encode(val)
                         }
                     }
 
@@ -89,11 +91,11 @@ public struct Interaction: Decodable {
                     ///
                     /// - Returns: The string value of a certain option if it is present and is of type `String`, otherwise `nil`
                     public func value() -> String? {
-                        guard case let .string(val) = self else {
-                            guard case let .user(val) = self else { return nil }
-                            return val
-                        }
-                        return val
+                        if case let .string(val) = self { return val }
+                        if case let .user(val) = self { return val }
+                        if case let .channel(val) = self { return val }
+
+                        return nil
                     }
                     /// Get the wrapped `Int` value
                     ///
@@ -151,6 +153,7 @@ public struct Interaction: Decodable {
                     case .boolean: value = .boolean(try container.decode(Bool.self, forKey: .value))
                     case .string: value = .string(try container.decode(String.self, forKey: .value))
                     case .user: value = .user(try container.decode(Snowflake.self, forKey: .value))
+                    case .channel: value = .channel(try container.decode(String.self, forKey: .value))
                     default: value = nil
                     }
                 }


### PR DESCRIPTION
Adds a `UserOption` to allow slash commands to select and target users.

This is a draft currently, as (a) I'm still ramping up on Swift (making a Discord bot is my first real use of it), and (b) while this _functions_, it is less than ideal, as the interaction data provides all of the user information but this currently only gives the ID to consuming code. Ideally, it should pull out the user data and make it available to users of the package nicely, but for now it's working as an MVP so I can actually use it.

As to why I've opened the PR, mostly it's so I can get a 'no don't do that' early on if I'm going down the wrong path, and possibly to look at expanding it out to adding more of the options as well.

I've also tweaked the `BotMessage` class as well, since there's a lot of useful info in the `Message` that seems to get thrown away (e.g. I want access to the author ID, as I want to filter out messages created by the bot itself when using the `createChannelMsg` method). If this isn't wanted, I'll revert it, not exactly attached to it.

For future reference (mostly for myself), this is an example interaction object (with all sensitive values stripped out):

<details>
<summary>Interaction Object</summary>

```json
{
  "t": "INTERACTION_CREATE",
  "s": 3,
  "op": 0,
  "d": {
    "version": 1,
    "type": 2,
    "token": "(string)",
    "member": {
      "user": {
        "username": "(string)",
        "public_flags": 0,
        "id": "(snowflake)",
        "global_name": "(string)",
        "discriminator": "0",
        "avatar_decoration": null,
        "avatar": "(string)"
      },
      "unusual_dm_activity_until": null,
      "roles": [
        "(snowflake)",
        "(snowflake)",
        "(snowflake)",
        "(snowflake)",
        "(snowflake)",
        "(snowflake)"
      ],
      "premium_since": null,
      "permissions": "(stringified int)",
      "pending": false,
      "nick": "(string)",
      "mute": false,
      "joined_at": "(ISO datetime)",
      "flags": 0,
      "deaf": false,
      "communication_disabled_until": null,
      "avatar": null
    },
    "locale": "en-GB",
    "id": "(snowflake)",
    "guild_locale": "ru",
    "guild_id": "(snowflake)",
    "guild": {
      "locale": "ru",
      "id": "(snowflake)",
      "features": [
        "THREE_DAY_THREAD_ARCHIVE",
        "SEVEN_DAY_THREAD_ARCHIVE",
        "MEMBER_PROFILES",
        "BANNER",
        "ROLE_ICONS",
        "PRIVATE_THREADS",
        "INVITE_SPLASH",
        "ANIMATED_ICON"
      ]
    },
    "entitlements": [],
    "entitlement_sku_ids": [],
    "data": {
      "type": 1,
      "resolved": {
        "users": {
          "(snowflake#1)": {
            "username": "(string)",
            "public_flags": 64,
            "id": "(snowflake#1)",
            "global_name": "(string)",
            "discriminator": "0",
            "avatar_decoration": null,
            "avatar": "(string)"
          }
        },
        "members": {
          "(snowflake#1)": {
            "unusual_dm_activity_until": null,
            "roles": [
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)",
              "(snowflake)"
            ],
            "premium_since": null,
            "permissions": "(stringified int)",
            "pending": false,
            "nick": "(string)",
            "joined_at": "(ISO datetime)",
            "flags": 0,
            "communication_disabled_until": null,
            "avatar": null
          }
        }
      },
      "options": [
        { "value": "(snowflake#1)", "type": 6, "name": "target" }
      ],
      "name": "(string:command name)",
      "id": "(snowflake)",
      "guild_id": "(snowflake)"
    },
    "channel_id": "(snowflake)",
    "channel": {
      "type": 0,
      "topic": "(string)",
      "rate_limit_per_user": 0,
      "position": 46,
      "permissions": "(stringified int)",
      "parent_id": "(snowflake)",
      "nsfw": true,
      "name": "(string)",
      "last_pin_timestamp": "(ISO datetime)",
      "last_message_id": "(snowflake)",
      "id": "(snowflake)",
      "guild_id": "(snowflake)",
      "flags": 0
    },
    "application_id": "(snowflake)",
    "app_permissions": "(stringified int)"
  }
}
```

</details>