### PR TITLE
Strip zlib header for best compression to fix communication with discord gateway

### DIFF
--- a/Sources/DiscordKitCore/Gateway/DecompressionEngine.swift
+++ b/Sources/DiscordKitCore/Gateway/DecompressionEngine.swift
@@ -79,7 +79,7 @@ public extension DecompressionEngine {
         decompressing = true
 
         // ZLib header, strip it if necessary
-        var data = data.prefix(2) == Data([0x78, 0x9C]) ? data.dropFirst(2) : data
+        var data = data.prefix(2) == Data([0x78, 0x9C]) || data.prefix(2) == Data([0x78, 0xDA]) ? data.dropFirst(2) : data
 
         // Configure stream source and destinations (will be changed in loop)
         stream.src_size = 0


### PR DESCRIPTION
This strips the zlib header for data sent by the gateway when compressed using best level compression as well as default compression. Either this is a new behavior from discord or it's dependent on what gateway server you hit - possibly due to a regional difference.

Resolves issue #35 