### PR TITLE
patch(README): import Foundation in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ in the DiscordKit guide.
 Create a simple bot with a **/ping** command:
 
 ```swift
+import Foundation
 import DiscordKitBot
 
 let bot = Client(intents: .unprivileged)


### PR DESCRIPTION
The example code from README.md did not compile without "import Foundation", at least on my Ubuntu 24.04 machine. This should hopefully save others some head scratching!